### PR TITLE
Fix wrong answer lock-up

### DIFF
--- a/src/components/GameBoard/GameBoard.tsx
+++ b/src/components/GameBoard/GameBoard.tsx
@@ -399,7 +399,6 @@ const GameBoard: React.FC<GameBoardProps> = ({ difficulty, onLevelComplete }) =>
     }
 
     const isAnswerCorrect = checkAnswer();
-    setIsComplete(true);
 
     const currentProgress = userService.getProgress(difficulty) || {
       totalTime: 0,
@@ -409,6 +408,7 @@ const GameBoard: React.FC<GameBoardProps> = ({ difficulty, onLevelComplete }) =>
     };
 
     if (isAnswerCorrect) {
+      setIsComplete(true);
       const newCorrectWords = currentProgress.correctWords + 1;
       console.log('Correct answer! Progress:', {
         current: currentProgress.correctWords,
@@ -456,6 +456,8 @@ const GameBoard: React.FC<GameBoardProps> = ({ difficulty, onLevelComplete }) =>
         }, 1000);
       }
     } else {
+      // Keep the board interactive for retries
+      setIsComplete(false);
       setIncorrectWords(prev => prev + 1);
       
       // Update incorrect words count


### PR DESCRIPTION
## Summary
- keep game board interactive when the answer is wrong
- only lock board when the player is correct

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68543120018c832b8cf5a40be46e6011